### PR TITLE
Include only retaken part if there were ver2 file

### DIFF
--- a/SweetHomeMaidPlayer/main_window.cpp
+++ b/SweetHomeMaidPlayer/main_window.cpp
@@ -645,9 +645,6 @@ void CMainWindow::SetPlayerFolder(const wchar_t* pwzFolderPath)
 /*再生ファイル群設定*/
 void CMainWindow::SetPlayFiles(const wchar_t* pwzImageFolderPath, const wchar_t* pwzAudioFolderPath)
 {
-    /*音声なし・画像なしの脚本あり*/
-    if (pwzImageFolderPath == nullptr)return;
-
     bool bRet = false;
 
     std::vector<std::wstring> imageFiles;
@@ -661,6 +658,20 @@ void CMainWindow::SetPlayFiles(const wchar_t* pwzImageFolderPath, const wchar_t*
     bRet = CreateFilePathList(pwzAudioFolderPath, L".mp3", audioFiles);
     if (bRet && m_pMediaPlayer != nullptr)
     {
+        auto IsVer2 = [](const std::wstring& wstr)
+            -> bool
+            {
+                return wcsstr(wstr.c_str(), L"_ver2") != nullptr;
+            };
+        size_t nRead = 0;
+        for (;;)
+        {
+            auto iter = std::find_if(audioFiles.begin() + nRead, audioFiles.end(), IsVer2);
+            if (iter == audioFiles.end() || iter == audioFiles.begin())break;
+            nRead = std::distance(audioFiles.begin(), iter);
+            audioFiles.erase(--iter);
+        }
+
         m_pMediaPlayer->SetFiles(audioFiles);
     }
 


### PR DESCRIPTION
Some audio parts are retaken.
<pre>
VoiceStoryCardcard103005
├ voice_story1030053_103_001.mp3
├ voice_story1030053_103_001_ver2.mp3
├ voice_story1030053_103_002.mp3
├ voice_story1030053_103_002_ver2.mp3
├ ...
├ voice_story1030053_103_015.mp3
├ voice_story1030053_103_015_ver2.mp3
└ ...
</pre>

Exclude older one from playback if there were ver2 file.